### PR TITLE
Readme 'n label fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -11,7 +11,7 @@ This repository holds all Dockerfiles and bash scripts to build the TeaSpeak Ser
     5. [View the Logs and get the Token](#view-the-logs-and-token)
     6. [Where to store data](#where-to-store-data)
 2. [Web Image](#web-image)
-    1. [Build and Run - Alpine Flavoured](#alpine-413mb-21-layers)
+    1. [Build and Run - Alpine Flavoured](#web-alpine-flavour)
     2. [Files and Volumes](#files-and-volumes)
     3. [EnvVars and Build-Args](#envvars-and-build-args-web)
     4. [Host the WebClient via `docker-compose`](#host-the-web-client-via-docker-compose)
@@ -194,13 +194,13 @@ The Docker documentation is a good starting point for understanding the differen
 
 ## Web Image
 
-[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/teaspeak/web?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
+[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/teaspeak/web?style=for-the-badge)](https://github.com/TeaSpeak/TeaWeb/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/teaspeak/web?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
 [![Official Image](https://img.shields.io/badge/Dockerhub-official-blue?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
 
 Basic instructions to build and host the TeaWeb client images yourself.
 
-### Alpine 
+### Web Alpine Flavour 
 
 [![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/teaspeak/web?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)
 [![MicroBadger Layers](https://img.shields.io/microbadger/layers/teaspeak/web?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)

--- a/README.MD
+++ b/README.MD
@@ -203,7 +203,7 @@ Basic instructions to build and host the TeaWeb client images yourself.
 
 ### Web Alpine Flavour 
 
-[![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/teaspeak/web?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)
+[![Docker Image Size (tag)](https://img.shields.io/docker/image-size/teaspeak/web/latest?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)
 [![MicroBadger Layers](https://img.shields.io/microbadger/layers/teaspeak/web?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)
 
 This image is based on the official Nginx Docker image (Alpine Linux flavour)

--- a/README.MD
+++ b/README.MD
@@ -194,9 +194,16 @@ The Docker documentation is a good starting point for understanding the differen
 
 ## Web Image
 
+![Docker Image Version (latest by date)](https://img.shields.io/docker/v/teaspeak/web?style=for-the-badge)
+![Docker Pulls](https://img.shields.io/docker/pulls/teaspeak/web?style=for-the-badge)
+
 Basic instructions to build and host the TeaWeb client images yourself.
 
-### Alpine (~41.3MB, 21 Layers)
+### Alpine 
+
+![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/teaspeak/web?style=for-the-badge)
+![MicroBadger Layers](https://img.shields.io/microbadger/layers/teaspeak/web?style=for-the-badge)
+
 This image is based on the official Nginx Docker image (Alpine Linux flavour)
 ```shell script
 # Build the image with the latest web release

--- a/README.MD
+++ b/README.MD
@@ -194,7 +194,8 @@ The Docker documentation is a good starting point for understanding the differen
 
 ## Web Image
 
-[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/teaspeak/web?style=for-the-badge)](https://github.com/TeaSpeak/TeaWeb/releases)
+[![Docker Image Version (tag latest semver)](https://img.shields.io/docker/v/teaspeak/web/latest?label=Release&style=for-the-badge)](https://github.com/TeaSpeak/TeaWeb/releases)
+[![Docker Image Version (tag latest beta semver)](https://img.shields.io/docker/v/teaspeak/web/beta?label=Development&color=orange&style=for-the-badge)](https://github.com/TeaSpeak/TeaWeb/releases)
 [![Docker Pulls](https://img.shields.io/docker/pulls/teaspeak/web?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
 [![Official Image](https://img.shields.io/badge/Dockerhub-official-blue?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
 

--- a/README.MD
+++ b/README.MD
@@ -194,15 +194,16 @@ The Docker documentation is a good starting point for understanding the differen
 
 ## Web Image
 
-![Docker Image Version (latest by date)](https://img.shields.io/docker/v/teaspeak/web?style=for-the-badge)
-![Docker Pulls](https://img.shields.io/docker/pulls/teaspeak/web?style=for-the-badge)
+[![Docker Image Version (latest by date)](https://img.shields.io/docker/v/teaspeak/web?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
+[![Docker Pulls](https://img.shields.io/docker/pulls/teaspeak/web?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
+[![Official Image](https://img.shields.io/badge/Dockerhub-official-blue?style=for-the-badge)](https://hub.docker.com/r/teaspeak/web)
 
 Basic instructions to build and host the TeaWeb client images yourself.
 
 ### Alpine 
 
-![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/teaspeak/web?style=for-the-badge)
-![MicroBadger Layers](https://img.shields.io/microbadger/layers/teaspeak/web?style=for-the-badge)
+[![Docker Image Size (latest by date)](https://img.shields.io/docker/image-size/teaspeak/web?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)
+[![MicroBadger Layers](https://img.shields.io/microbadger/layers/teaspeak/web?style=for-the-badge)](https://microbadger.com/images/teaspeak/web)
 
 This image is based on the official Nginx Docker image (Alpine Linux flavour)
 ```shell script

--- a/server/alpine.Dockerfile
+++ b/server/alpine.Dockerfile
@@ -35,7 +35,7 @@ EXPOSE 9987/tcp 9987/udp 10101/tcp 30303/tcp
 VOLUME ["/ts/logs", "/ts/certs", "/ts/config", "/ts/files", "/ts/database", "/ts/crash_dumps"]
 
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/ts/libs/" \
-    SERVER_VERSION="${SERVER_VERSION}" \
+    SERVER_VERSION="${SERVER_VERSION:-latest-$(date +%d%m%y)}" \
     TZ="Europe/Berlin"
 
 USER teaspeak

--- a/server/alpine.Dockerfile
+++ b/server/alpine.Dockerfile
@@ -1,6 +1,6 @@
 FROM frolvlad/alpine-glibc:latest
 
-LABEL varion="1.0" \
+LABEL version="1.0" \
     maintainer="Markus Hadenfeldt <docker@teaspeak.de>, h1dden-da3m0n" \
     description="A simple TeaSpeak server running on alpine-glibc (amd64_stable)"
 

--- a/server/debian.Dockerfile
+++ b/server/debian.Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:10-slim
 
-LABEL varion="2.0" \
+LABEL version="2.0" \
     maintainer="ESh4d0w, Markus Hadenfeldt <docker@teaspeak.de>, h1dden-da3m0n" \
     description="A simple TeaSpeak server running on debian 10 (amd64_stable)"
 

--- a/server/debian.Dockerfile
+++ b/server/debian.Dockerfile
@@ -39,7 +39,7 @@ VOLUME ["/ts/logs", "/ts/certs", "/ts/config", "/ts/files", "/ts/database", "/ts
 
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/ts/libs/" \
     LD_PRELOAD="/ts/libs/libjemalloc.so.2" \
-    SERVER_VERSION="${SERVER_VERSION}" \
+    SERVER_VERSION="${SERVER_VERSION:-latest-$(date +%d%m%y)}" \
     TZ="Europe/Berlin"
 
 USER teaspeak

--- a/server/ubuntu.Dockerfile
+++ b/server/ubuntu.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-LABEL varion="2.0" \
+LABEL version="2.0" \
     maintainer="ESh4d0w, Markus Hadenfeldt <docker@teaspeak.de>, h1dden-da3m0n" \
     description="A simple TeaSpeak server running on ubuntu 18.04 (amd64_stable)"
 

--- a/server/ubuntu.Dockerfile
+++ b/server/ubuntu.Dockerfile
@@ -39,7 +39,7 @@ VOLUME ["/ts/logs", "/ts/certs", "/ts/config", "/ts/files", "/ts/database", "/ts
 
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/ts/libs/" \
     LD_PRELOAD="/ts/libs/libjemalloc.so.2" \
-    SERVER_VERSION="${SERVER_VERSION}" \
+    SERVER_VERSION="${SERVER_VERSION:-latest-$(date +%d%m%y)}" \
     TZ="Europe/Berlin"
 
 USER teaspeak

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
-LABEL varion="1.0" \
+LABEL version="1.0" \
     maintainer="Markus Hadenfeldt <docker@teaspeak.de>, h1dden-da3m0n" \
     description="A simple TeaSpeak WebClient running on Nginx-Alpine"
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -24,7 +24,7 @@ RUN apk update --no-cache && apk upgrade --no-cache \
     \
     && apk del --no-cache curl jq
 
-ENV WEB_VERSION="${WEB_VERSION}" \
+ENV WEB_VERSION="${WEB_VERSION:-latest-$(date +%d%m%y)}" \
     TZ="Europe/Berlin"
 
 VOLUME ["/etc/ssl/certs"]

--- a/web/travis.Dockerfile
+++ b/web/travis.Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:alpine
 
 # ONYL FOR BUILD AUTOMATION USE OR IF YOU KNOW WHAT YOU ARE DONG!
-LABEL varion="1.0" \
+LABEL version="1.0" \
     maintainer="Markus Hadenfeldt <docker@teaspeak.de>, h1dden-da3m0n" \
     description="A simple TeaSpeak WebClient running on Nginx-Alpine"
 


### PR DESCRIPTION
Noticed that I messed up one of the Labels spelling :rofl: as well as on setting the *_Version ENV so here I go.

# Changes

* Fixes Dockerfile label typo
* Fixes Dockerfile ENV setting error if building latest
* adds live badges to the Web readme section